### PR TITLE
handle correctly `CMake` transitive dependencies

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -1203,7 +1203,7 @@ class CMakeInterpreter:
             # declare_dependency kwargs
             dep_kwargs: TYPE_mixed_kwargs = {
                 'link_args': tgt.link_flags + tgt.link_libraries,
-                'link_with': id_node(tgt_var),
+                'link_with': [ id_node(tgt_var), link_with ],
                 'compile_args': tgt.public_compile_opts,
                 'include_directories': id_node(inc_var),
             }

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -1203,7 +1203,7 @@ class CMakeInterpreter:
             # declare_dependency kwargs
             dep_kwargs: TYPE_mixed_kwargs = {
                 'link_args': tgt.link_flags + tgt.link_libraries,
-                'link_with': [ id_node(tgt_var), link_with ],
+                'link_with': [id_node(tgt_var)] + link_with,
                 'compile_args': tgt.public_compile_opts,
                 'include_directories': id_node(inc_var),
             }

--- a/test cases/cmake/29 nested deps/main.cpp
+++ b/test cases/cmake/29 nested deps/main.cpp
@@ -1,18 +1,11 @@
 #include <iostream>
 
-#define cmModClass cmModClass1
-#include <cmMod.hpp>
-
-#undef cmModClass
-#define cmModClass cmModClass2
 #include <cmMod.hpp>
 
 using namespace std;
 
 int main(void) {
-  cmModClass1 obj1("Hello1");
-  cmModClass2 obj2("Hello2");
-  cout << obj1.getStr() << endl;
-  cout << obj2.getStr() << endl;
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
   return 0;
 }

--- a/test cases/cmake/29 nested deps/meson.build
+++ b/test cases/cmake/29 nested deps/meson.build
@@ -1,4 +1,4 @@
-project('cmakeSubTest', ['c', 'cpp'])
+project('cmakeSubTest', ['c', 'cpp'], default_options: ['cpp_std=c++14'])
 
 cm = import('cmake')
 opts = cm.subproject_options()

--- a/test cases/cmake/29 nested deps/meson.build
+++ b/test cases/cmake/29 nested deps/meson.build
@@ -1,9 +1,18 @@
 project('cmakeSubTest', ['c', 'cpp'])
 
 cm = import('cmake')
+opts = cm.subproject_options()
 
-sub_pro = cm.subproject('cmMod')
-sub_dep = sub_pro.dependency('cmModLib1', include_type: 'system')
+if get_option('default_library') == 'static'
+  opts.add_cmake_defines({'DEFAULT_LIBRARY': 'STATIC'})
+elif get_option('default_library') == 'shared'
+  opts.add_cmake_defines({'DEFAULT_LIBRARY': 'SHARED'})
+else
+  error('Specify default_library')
+endif
+
+sub_pro = cm.subproject('cmMod', options: opts)
+sub_dep = sub_pro.dependency('cmModLib++')
 
 exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
 test('test1', exe1)

--- a/test cases/cmake/29 nested deps/meson.options
+++ b/test cases/cmake/29 nested deps/meson.options
@@ -1,0 +1,1 @@
+option('test_read', type: 'boolean', value: false)

--- a/test cases/cmake/29 nested deps/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/29 nested deps/subprojects/cmMod/CMakeLists.txt
@@ -3,10 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-add_library(cmModLib1 STATIC cmMod.cpp)
-add_library(cmModLib2 STATIC cmMod.cpp)
-target_compile_definitions(cmModLib1 PRIVATE cmModClass=cmModClass1)
-target_compile_definitions(cmModLib2 PRIVATE cmModClass=cmModClass2)
-target_link_libraries(cmModLib1 PUBLIC cmModLib2)
+add_library(cmModLib++ ${DEFAULT_LIBRARY} cmMod.cpp)
+add_library(cmModLibInternal ${DEFAULT_LIBRARY} cmMod_internal.cpp)
+target_link_libraries(cmModLib++ PUBLIC cmModLibInternal)

--- a/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod.cpp
@@ -1,11 +1,1 @@
 #include "cmMod.hpp"
-
-using namespace std;
-
-cmModClass::cmModClass(string foo) {
-  str = foo + " World";
-}
-
-string cmModClass::getStr() const {
-  return str;
-}

--- a/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod.hpp
@@ -1,11 +1,7 @@
+#include "cmMod_internal.hpp"
 #include <string>
 
-class cmModClass {
-private:
-  std::string str;
-
+class cmModClass : public cmModInternalClass {
 public:
-  cmModClass(std::string foo);
-
-  std::string getStr() const;
+  using cmModInternalClass::cmModInternalClass;
 };

--- a/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod_internal.cpp
+++ b/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod_internal.cpp
@@ -1,0 +1,11 @@
+#include "cmMod_internal.hpp"
+
+using namespace std;
+
+cmModInternalClass::cmModInternalClass(const std::string &foo) {
+  str = "Hello " + foo;
+}
+
+string cmModInternalClass::getStr() const {
+  return str;
+}

--- a/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod_internal.hpp
+++ b/test cases/cmake/29 nested deps/subprojects/cmMod/cmMod_internal.hpp
@@ -1,0 +1,10 @@
+#include <string>
+
+class cmModInternalClass {
+private:
+  std::string str;
+
+public:
+  cmModInternalClass(const std::string &foo);
+  std::string getStr() const;
+};

--- a/test cases/cmake/29 nested deps/test.json
+++ b/test cases/cmake/29 nested deps/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "default_library": [
+        { "val": "shared" },
+        { "val": "static" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
correctly export transitive dependencies to the final returned `dependency` object

Fixes #21 